### PR TITLE
v3-brwac: tf.data training, robust cleaning, and top-k/top-p generation

### DIFF
--- a/compare_generate_v2.py
+++ b/compare_generate_v2.py
@@ -1,0 +1,179 @@
+import argparse
+import os
+import pickle
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import tensorflow as tf
+
+
+@dataclass
+class ModelSpec:
+    name: str
+    model_path: str
+    mapping_path: str
+
+
+def load_mappings(mapping_path: str) -> Tuple[Dict[str, int], Dict[int, str], int | None]:
+    with open(mapping_path, "rb") as f:
+        mp = pickle.load(f)
+    # Normalizar chaves entre versões
+    if "char_para_int" in mp and "int_para_char" in mp:
+        c2i = mp["char_para_int"]
+        i2c = mp["int_para_char"]
+    elif "char_to_id" in mp and "id_to_char" in mp:
+        c2i = mp["char_to_id"]
+        i2c = mp["id_to_char"]
+    else:
+        c2i = mp.get("char_to_idx") or mp.get("char_to_int") or mp.get("char2idx")
+        i2c = mp.get("idx_to_char") or mp.get("int_to_char") or mp.get("idx2char")
+        if c2i is None or i2c is None:
+            raise ValueError(f"Formato de mapeamentos desconhecido em {mapping_path}")
+    try:
+        i2c = {int(k): v for k, v in i2c.items()}
+    except Exception:
+        pass
+    seq_len = mp.get("tamanho_sequencia")
+    return c2i, i2c, seq_len
+
+
+def stable_softmax(logits: np.ndarray) -> np.ndarray:
+    m = np.max(logits)
+    e = np.exp(logits - m)
+    return e / np.sum(e)
+
+
+def sample_topk_topp(probs: np.ndarray, temperature: float, top_k: int, top_p: float, rng: np.random.Generator) -> int:
+    p = np.asarray(probs, dtype=np.float64)
+    p = np.maximum(p, 1e-9)
+    # Converter para logits e aplicar temperatura
+    logits = np.log(p)
+    if temperature > 0:
+        logits = logits / temperature
+
+    # Top-k em logits
+    if top_k and top_k > 0 and top_k < logits.shape[0]:
+        kth = np.argpartition(-logits, top_k - 1)[top_k - 1]
+        thresh = logits[kth]
+        mask = logits < thresh
+        logits[mask] = -np.inf
+
+    # Softmax após top-k
+    p = stable_softmax(logits)
+
+    # Top-p (nucleus) em probs
+    if top_p and 0 < top_p < 1.0:
+        idx_sorted = np.argsort(-p)
+        cumsum = np.cumsum(p[idx_sorted])
+        keep = cumsum <= top_p
+        # garantir pelo menos 1
+        if not np.any(keep):
+            keep[0] = True
+        mask = np.ones_like(p, dtype=bool)
+        mask[idx_sorted[keep]] = False
+        p[mask] = 0.0
+        s = p.sum()
+        if s > 0:
+            p = p / s
+
+    return int(rng.choice(len(p), p=p))
+
+
+def infer_shapes(model: tf.keras.Model) -> Tuple[str, int | None, int | None]:
+    ishape = model.input_shape
+    if len(ishape) == 2:
+        return "embedding", ishape[1], None
+    if len(ishape) == 3:
+        return "onehot", ishape[1], ishape[2]
+    raise ValueError(f"Forma de entrada inesperada: {ishape}")
+
+
+def prepare_seed_indices(seed: str, c2i: Dict[str, int], seq_len: int) -> List[int]:
+    rep = " " if " " in c2i else next(iter(c2i.keys()))
+    filtered = [ch if ch in c2i else rep for ch in seed]
+    idxs = [c2i[ch] for ch in filtered]
+    if len(idxs) < seq_len:
+        pad_idx = c2i.get(" ", idxs[0] if idxs else 0)
+        idxs = [pad_idx] * (seq_len - len(idxs)) + idxs
+    else:
+        idxs = idxs[-seq_len:]
+    return idxs
+
+
+def generate_text(
+    model: tf.keras.Model,
+    c2i: Dict[str, int],
+    i2c: Dict[int, str],
+    seed: str,
+    length: int,
+    temperature: float,
+    rng: np.random.Generator,
+    top_k: int,
+    top_p: float,
+) -> str:
+    input_type, seq_len, onehot_vocab = infer_shapes(model)
+    if seq_len is None:
+        seq_len = 100
+    vocab_size = len(i2c)
+    seq = prepare_seed_indices(seed, c2i, seq_len)
+    out_chars = []
+    for _ in range(length):
+        if input_type == "embedding":
+            x = np.array(seq, dtype=np.int32)[None, :]
+        else:
+            x = np.zeros((1, seq_len, vocab_size if onehot_vocab is None else onehot_vocab), dtype=np.float32)
+            for t, idx in enumerate(seq):
+                if idx < x.shape[2]:
+                    x[0, t, idx] = 1.0
+        preds = model(x, training=False).numpy()[0]
+        if preds.ndim > 1:
+            preds = preds[-1]
+        next_idx = sample_topk_topp(preds, temperature, top_k, top_p, rng)
+        out_chars.append(i2c.get(next_idx, "?"))
+        seq = seq[1:] + [next_idx]
+    return "".join(out_chars)
+
+
+def run_compare(prompt: str, length: int, temperature: float, specs: List[ModelSpec], seed: int, top_k: int, top_p: float) -> None:
+    rng = np.random.default_rng(seed)
+    tf.random.set_seed(seed)
+    for spec in specs:
+        if not os.path.exists(spec.model_path):
+            print(f"[WARN] {spec.name}: modelo ausente: {spec.model_path}")
+            continue
+        if not os.path.exists(spec.mapping_path):
+            print(f"[WARN] {spec.name}: mapeamentos ausentes: {spec.mapping_path}")
+            continue
+        print(f"\n=== {spec.name} ===")
+        c2i, i2c, _ = load_mappings(spec.mapping_path)
+        model = tf.keras.models.load_model(spec.model_path)
+        gen = generate_text(model, c2i, i2c, prompt, length, temperature, rng, top_k, top_p)
+        print(f"Prompt: {prompt}")
+        print(f"Output: {gen}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Comparar geração de texto entre v1, v2, v3 com o mesmo prompt (top-k/top-p)")
+    parser.add_argument("--prompt", type=str, default="O Brasil ")
+    parser.add_argument("--length", type=int, default=300)
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--only", type=str, default="", help="Comma: v1,v2,v3 para filtrar")
+    parser.add_argument("--top_k", type=int, default=40, help="Top-k (0 desabilita)")
+    parser.add_argument("--top_p", type=float, default=0.95, help="Top-p/Nucleus (0 desabilita)")
+    args = parser.parse_args()
+
+    all_specs = {
+        "v1": ModelSpec("v1-char-rnn", "versions/v1-char-rnn/models/modelo_char_rnn.keras", "versions/v1-char-rnn/mappings/mapeamentos.pkl"),
+        "v2": ModelSpec("v2-char-lm", "versions/v2-char-lm/models/modelo_char_lm_v2.keras", "versions/v2-char-lm/mappings/mapeamentos_v2.pkl"),
+        "v3": ModelSpec("v3-brwac", "versions/v3-brwac/models/modelo_brwac.keras", "versions/v3-brwac/mappings/mapeamentos_brwac.pkl"),
+    }
+    keys = [k.strip() for k in args.only.split(",") if k.strip()] if args.only else ["v1", "v2", "v3"]
+    specs = [all_specs[k] for k in keys if k in all_specs]
+    run_compare(args.prompt, args.length, args.temperature, specs, args.seed, args.top_k, args.top_p)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/llm_generico_v2.py
+++ b/llm_generico_v2.py
@@ -1,0 +1,174 @@
+import os
+import pickle
+from dataclasses import dataclass
+from typing import Dict, Tuple, Optional
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import layers, models, optimizers
+
+
+@dataclass
+class TreinoConfigV2:
+    tamanho_sequencia: int = 160
+    tamanho_lstm: int = 256
+    embedding_dim: int = 128
+    epocas_treino: int = 10
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    stride: int = 3
+    shuffle_buffer: int = 10000
+    dropout: float = 0.2
+    recurrent_dropout: float = 0.0
+    clipnorm: float | None = 1.0
+
+
+class LLMSimplesGenericoV2:
+    """
+    LLM simples por caracteres usando Keras (Embedding + LSTM + Softmax),
+    treinado com tf.data para janelas deslizantes eficientes.
+    """
+
+    def __init__(
+        self,
+        tamanho_sequencia: int = 160,
+        tamanho_lstm: int = 256,
+        embedding_dim: int = 128,
+        epocas_treino: int = 10,
+        batch_size: int = 128,
+        learning_rate: float = 1e-3,
+        stride: int = 3,
+        shuffle_buffer: int = 10000,
+        dropout: float = 0.2,
+        recurrent_dropout: float = 0.0,
+        clipnorm: float | None = 1.0,
+    ) -> None:
+        self.cfg = TreinoConfigV2(
+            tamanho_sequencia=tamanho_sequencia,
+            tamanho_lstm=tamanho_lstm,
+            embedding_dim=embedding_dim,
+            epocas_treino=epocas_treino,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            stride=stride,
+            shuffle_buffer=shuffle_buffer,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            clipnorm=clipnorm,
+        )
+        self.model: tf.keras.Model | None = None
+        self.char_to_idx: Dict[str, int] | None = None
+        self.idx_to_char: Dict[int, str] | None = None
+
+    # ------------------------------
+    # Público
+    # ------------------------------
+    def treinar(
+        self,
+        caminho_texto: str,
+        nome_arquivo_modelo: str,
+        nome_arquivo_maps: str,
+        callbacks: Optional[list[tf.keras.callbacks.Callback]] = None,
+        caminho_texto_validacao: Optional[str] = None,
+    ) -> None:
+        texto_train = self._ler_texto(caminho_texto)
+        self.char_to_idx, self.idx_to_char = self._criar_mapeamentos(texto_train)
+
+        seq_train = self._texto_para_indices(texto_train, self.char_to_idx)
+        ds_train = self._seq_para_dataset(seq_train, treino=True)
+
+        ds_val = None
+        if caminho_texto_validacao:
+            texto_val = self._ler_texto(caminho_texto_validacao)
+            seq_val = self._texto_para_indices(texto_val, self.char_to_idx, unk_idx=self._unk_idx())
+            ds_val = self._seq_para_dataset(seq_val, treino=False)
+
+        vocab_size = len(self.char_to_idx)
+        self.model = self._construir_modelo(vocab_size)
+
+        self.model.fit(
+            ds_train,
+            epochs=self.cfg.epocas_treino,
+            validation_data=ds_val if ds_val is not None else None,
+            callbacks=callbacks if callbacks else None,
+            verbose=2,
+        )
+
+        # Garantir diretórios de saída
+        os.makedirs(os.path.dirname(nome_arquivo_modelo) or ".", exist_ok=True)
+        os.makedirs(os.path.dirname(nome_arquivo_maps) or ".", exist_ok=True)
+
+        # Salvar artefatos
+        self.model.save(nome_arquivo_modelo)
+        self._salvar_mapeamentos(nome_arquivo_maps)
+
+    # ------------------------------
+    # Internos
+    # ------------------------------
+    @staticmethod
+    def _ler_texto(caminho: str) -> str:
+        with open(caminho, "r", encoding="utf-8") as f:
+            return f.read()
+
+    @staticmethod
+    def _criar_mapeamentos(texto: str) -> Tuple[Dict[str, int], Dict[int, str]]:
+        vocab = sorted(list(set(texto)))
+        char_to_idx = {ch: i for i, ch in enumerate(vocab)}
+        idx_to_char = {i: ch for ch, i in char_to_idx.items()}
+        return char_to_idx, idx_to_char
+
+    @staticmethod
+    def _texto_para_indices(texto: str, char_to_idx: Dict[str, int], unk_idx: int | None = None) -> np.ndarray:
+        seq: list[int] = []
+        for ch in texto:
+            if ch in char_to_idx:
+                seq.append(char_to_idx[ch])
+            elif unk_idx is not None:
+                seq.append(unk_idx)
+            # else: ignora
+        return np.array(seq, dtype=np.int32)
+
+    def _seq_para_dataset(self, seq: np.ndarray, treino: bool) -> tf.data.Dataset:
+        if len(seq) <= self.cfg.tamanho_sequencia:
+            raise ValueError("Texto muito curto para o tamanho de sequência escolhido.")
+        ds = tf.data.Dataset.from_tensor_slices(seq)
+        ds = ds.window(self.cfg.tamanho_sequencia + 1, shift=self.cfg.stride, drop_remainder=True)
+        ds = ds.flat_map(lambda w: w.batch(self.cfg.tamanho_sequencia + 1))
+        ds = ds.map(lambda w: (w[:-1], w[-1]), num_parallel_calls=tf.data.AUTOTUNE)
+        if treino:
+            ds = ds.shuffle(self.cfg.shuffle_buffer, reshuffle_each_iteration=True)
+        ds = ds.batch(self.cfg.batch_size).prefetch(tf.data.AUTOTUNE)
+        return ds
+
+    def _construir_modelo(self, vocab_size: int) -> tf.keras.Model:
+        model = models.Sequential([
+            layers.Input(shape=(self.cfg.tamanho_sequencia,)),
+            layers.Embedding(input_dim=vocab_size, output_dim=self.cfg.embedding_dim),
+            layers.LSTM(self.cfg.tamanho_lstm, dropout=self.cfg.dropout, recurrent_dropout=self.cfg.recurrent_dropout),
+            layers.Dense(vocab_size, activation="softmax"),
+        ])
+        if self.cfg.clipnorm is not None and self.cfg.clipnorm > 0:
+            opt = optimizers.Adam(learning_rate=self.cfg.learning_rate, clipnorm=self.cfg.clipnorm)
+        else:
+            opt = optimizers.Adam(learning_rate=self.cfg.learning_rate)
+        model.compile(optimizer=opt, loss="sparse_categorical_crossentropy", metrics=["accuracy"])
+        return model
+
+    def _unk_idx(self) -> int:
+        # Fallback para caractere desconhecido, usa espaço se existir, senão 0
+        assert self.char_to_idx is not None
+        return self.char_to_idx.get(" ", 0)
+
+    def _salvar_mapeamentos(self, caminho_maps: str) -> None:
+        assert self.char_to_idx is not None and self.idx_to_char is not None
+        payload = {
+            "char_to_idx": self.char_to_idx,
+            "idx_to_char": self.idx_to_char,
+            "tamanho_sequencia": self.cfg.tamanho_sequencia,
+            "embedding_dim": self.cfg.embedding_dim,
+            "tamanho_lstm": self.cfg.tamanho_lstm,
+            "stride": self.cfg.stride,
+        }
+        with open(caminho_maps, "wb") as f:
+            pickle.dump(payload, f)
+

--- a/versions/v3-brwac/README_v2.md
+++ b/versions/v3-brwac/README_v2.md
@@ -1,0 +1,40 @@
+# v3 - BrWaC (tf.data) — Script V2
+
+Treinamento por caracteres com BrWaC usando tf.data (janelas com stride) e limpeza de texto mais robusta (tratando marcadores `<END>` como separadores de documento).
+
+## Scripts
+- Treino (novo): `versions/v3-brwac/scripts/treinar_com_brwac_tfdata.py`
+- Comparação com top-k/top-p (novo): `compare_generate_v2.py`
+
+## Principais melhorias
+- Split de validação por documento (sem `validation_split` por janelas).
+- `tf.data` para gerar janelas sob demanda, com `--stride`, `--shuffle_buffer` e `prefetch`.
+- Hiperparâmetros extras: `--embedding_dim`, `--dropout`, `--recurrent_dropout`, `--clipnorm`.
+- Limpeza: Unicode NFKC, remoção de controles, preserva quebras e trata `<END>` como separador.
+- Seeds fixos para reprodutibilidade.
+
+## Exemplo — Treinamento
+```
+python versions/v3-brwac/scripts/treinar_com_brwac_tfdata.py \
+  --epocas 10 --max_textos 10000 \
+  --tamanho_sequencia 160 --tamanho_lstm 256 --embedding_dim 128 \
+  --batch_size 256 --stride 3 --dropout 0.2 --clipnorm 1.0 \
+  --validacao_split 0.1
+```
+
+Artefatos gerados:
+- Modelo: `versions/v3-brwac/models/modelo_brwac.keras`
+- Mapeamentos: `versions/v3-brwac/mappings/mapeamentos_brwac.pkl`
+
+## Exemplo — Geração com top‑k/top‑p
+```
+python compare_generate_v2.py \
+  --only v3 --prompt "Seu prompt" --length 400 \
+  --temperature 0.8 --top_k 40 --top_p 0.95
+```
+
+## Dicas
+- Aumente `--stride` para reduzir custo (ex.: 5–8) se o corpus for grande.
+- Se overfitting: aumente `--dropout`, use `--tamanho_lstm 512` apenas com GPU.
+- Se memória for limite: reduza `--batch_size` e/ou `--tamanho_lstm`.
+

--- a/versions/v3-brwac/scripts/treinar_com_brwac_tfdata.py
+++ b/versions/v3-brwac/scripts/treinar_com_brwac_tfdata.py
@@ -1,0 +1,188 @@
+import argparse
+import os
+import random
+import tempfile
+import unicodedata
+
+import numpy as np
+import tensorflow as tf
+from datasets import load_dataset
+from llm_generico_v2 import LLMSimplesGenericoV2
+
+
+def preparar_texto(
+    texto: str,
+    lowercase: bool = True,
+    boundary_token: str | None = "\n⟂\n",
+    end_marker: str = "<END>",
+) -> str:
+    """Limpeza mais robusta para BrWaC.
+    - Normaliza Unicode (NFKC) e remove caracteres de controle
+    - Converte <END> em separador de documentos
+    - Consolida espaços mantendo quebras de linha
+    - Lowercase opcional
+    """
+    # Unicode normalize
+    texto = unicodedata.normalize("NFKC", texto)
+    # Remover controles (exceto \n, \t)
+    texto = "".join(ch for ch in texto if ch == "\n" or ch == "\t" or ord(ch) >= 32)
+    # Marcas de seção como quebras de documento
+    if end_marker:
+        texto = texto.replace(end_marker, boundary_token or "\n")
+    # Normalizar quebras
+    texto = texto.replace("\r", "")
+
+    def _squash_spaces(line: str) -> str:
+        while "  " in line:
+            line = line.replace("  ", " ")
+        return line.strip()
+
+    linhas = [l for l in ( _squash_spaces(l) for l in texto.split("\n") ) if l != ""]
+    texto = "\n".join(linhas)
+    if lowercase:
+        texto = texto.lower()
+    return texto
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Treinar LLM (char) com BrWaC usando tf.data")
+    # Dados/limpeza
+    parser.add_argument("--max_textos", type=int, default=50000, help="Número máximo de textos de treino")
+    parser.add_argument("--min_len", type=int, default=50, help="Comprimento mínimo por documento")
+    parser.add_argument("--seed", type=int, default=42, help="Seed de reprodução")
+    parser.add_argument("--no_lowercase", action="store_true", help="Não converter para minúsculas")
+    # Modelo/treino
+    parser.add_argument("--epocas", type=int, default=10, help="Épocas de treino")
+    parser.add_argument("--tamanho_sequencia", type=int, default=160, help="Comprimento da janela")
+    parser.add_argument("--batch_size", type=int, default=128, help="Batch size")
+    parser.add_argument("--tamanho_lstm", type=int, default=256, help="Unidades LSTM")
+    parser.add_argument("--embedding_dim", type=int, default=128, help="Dimensão do embedding")
+    parser.add_argument("--stride", type=int, default=3, help="Passo entre janelas")
+    parser.add_argument("--shuffle_buffer", type=int, default=10000, help="Buffer de shuffle")
+    parser.add_argument("--dropout", type=float, default=0.2, help="Dropout LSTM")
+    parser.add_argument("--recurrent_dropout", type=float, default=0.0, help="Recurrent dropout LSTM")
+    parser.add_argument("--clipnorm", type=float, default=1.0, help="Clip norm (0 desabilita)")
+    parser.add_argument("--validacao_split", type=float, default=0.1, help="Proporção doc-level validação")
+    # Saída
+    parser.add_argument(
+        "--modelo_saida",
+        type=str,
+        default="versions/v3-brwac/models/modelo_brwac.keras",
+        help="Arquivo de modelo (.keras)",
+    )
+    parser.add_argument(
+        "--mapeamentos_saida",
+        type=str,
+        default="versions/v3-brwac/mappings/mapeamentos_brwac.pkl",
+        help="Arquivo de mapeamentos (.pkl)",
+    )
+
+    args = parser.parse_args()
+
+    # Seeds
+    os.environ["PYTHONHASHSEED"] = str(args.seed)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    tf.random.set_seed(args.seed)
+
+    print("Carregando dataset BrWaC (split 'train')...")
+    dataset = load_dataset("nlpufg/brwac")
+    ds_train_full = dataset["train"].shuffle(seed=args.seed)
+    print(f"Dataset carregado com {len(ds_train_full)} exemplos")
+
+    # Split por documento
+    if args.validacao_split and 0.0 < args.validacao_split < 1.0:
+        split = ds_train_full.train_test_split(test_size=args.validacao_split, seed=args.seed)
+        ds_train = split["train"]
+        ds_val = split["test"]
+        print(f"Split doc-level -> train: {len(ds_train)}, val: {len(ds_val)}")
+    else:
+        ds_train = ds_train_full
+        ds_val = None
+
+    # Amostragem limitada
+    max_train = min(args.max_textos, len(ds_train))
+    max_val = min(int(args.max_textos * args.validacao_split), len(ds_val)) if ds_val else 0
+    print(f"Preparando até {max_train} textos de treino e {max_val} de validação...")
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, encoding="utf-8") as ftrain:
+        caminho_texto_train = ftrain.name
+        count_t = 0
+        for exemplo in ds_train:
+            if count_t >= max_train:
+                break
+            texto = exemplo["text"]
+            texto_p = preparar_texto(texto, lowercase=(not args.no_lowercase))
+            if len(texto_p) >= args.min_len:
+                ftrain.write(texto_p + "\n\n")
+                count_t += 1
+                if count_t % 5000 == 0:
+                    print(f"Treino: processados {count_t} textos...")
+        print(f"Treino: processados {count_t} textos no total")
+
+    caminho_texto_val = None
+    count_v = 0
+    if ds_val is not None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, encoding="utf-8") as fval:
+            caminho_texto_val = fval.name
+            for exemplo in ds_val:
+                if count_v >= max_val:
+                    break
+                texto = exemplo["text"]
+                texto_p = preparar_texto(texto, lowercase=(not args.no_lowercase))
+                if len(texto_p) >= args.min_len:
+                    fval.write(texto_p + "\n\n")
+                    count_v += 1
+                    if count_v % 2000 == 0:
+                        print(f"Val: processados {count_v} textos...")
+            print(f"Val: processados {count_v} textos no total")
+
+    try:
+        llm = LLMSimplesGenericoV2(
+            tamanho_sequencia=args.tamanho_sequencia,
+            tamanho_lstm=args.tamanho_lstm,
+            embedding_dim=args.embedding_dim,
+            epocas_treino=args.epocas,
+            batch_size=args.batch_size,
+            learning_rate=1e-3,
+            stride=args.stride,
+            shuffle_buffer=args.shuffle_buffer,
+            dropout=args.dropout,
+            recurrent_dropout=args.recurrent_dropout,
+            clipnorm=args.clipnorm if args.clipnorm and args.clipnorm > 0 else None,
+        )
+
+        print("Iniciando treinamento...")
+        monitor = "val_loss" if caminho_texto_val else "loss"
+        cb = [
+            tf.keras.callbacks.ModelCheckpoint(
+                filepath=args.modelo_saida,
+                save_best_only=True,
+                monitor=monitor,
+                mode="min",
+            ),
+            tf.keras.callbacks.ReduceLROnPlateau(monitor=monitor, factor=0.5, patience=3, min_lr=5e-5),
+            tf.keras.callbacks.EarlyStopping(monitor=monitor, patience=5, restore_best_weights=True),
+        ]
+
+        llm.treinar(
+            caminho_texto=caminho_texto_train,
+            nome_arquivo_modelo=args.modelo_saida,
+            nome_arquivo_maps=args.mapeamentos_saida,
+            callbacks=cb,
+            caminho_texto_validacao=caminho_texto_val,
+        )
+        print(f"Treinamento concluído! Modelo salvo em '{args.modelo_saida}'")
+    finally:
+        # Limpar arquivos temporários
+        for p in [caminho_texto_train, caminho_texto_val]:
+            if p:
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
- Add LLMSimplesGenericoV2 (tf.data windows with stride, dropout, clipnorm, seeds).

- Add training script treinar_com_brwac_tfdata.py with doc-level split and cleaning (<END> -> ⟂).

- Add compare_generate_v2.py with top-k/top-p and faster inference path.

- Add README_v2.md with usage and examples.

- Keep original v3 script to preserve compatibility.